### PR TITLE
Changed timeout_millis to delay, allowing reload to wait until the server is up

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Options:
   -d, --dir [dir]               The directory to serve up. Defaults to current dir.
   -e, --exts [extensions]       Extensions separated by commas or pipes. Defaults to html,js,css.
   -p, --port [port]             The port to bind to. Can be set with PORT env variable as well. Defaults to 8080
-  -t, --time [delay]            How long (ms) should the browser wait before reconnecting? Defaults to 300 ms.
+  -d, --delay [delay]           How long (ms) should the browser wait before reconnecting? Defaults to 300 ms.
   -s, --start-page [start-page] Specify a start page. Defaults to index.html.
 
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Options:
   -d, --dir [dir]               The directory to serve up. Defaults to current dir.
   -e, --exts [extensions]       Extensions separated by commas or pipes. Defaults to html,js,css.
   -p, --port [port]             The port to bind to. Can be set with PORT env variable as well. Defaults to 8080
-  -d, --delay [delay]           How long (ms) should the browser wait before reconnecting? Defaults to 300 ms.
+  -d, --delay [delay]           How long (ms) should the browser wait before reconnecting? You can also specify true, if you would like reload to wait until the server comes back up before reloading the page. Defaults to 300 ms.
   -s, --start-page [start-page] Specify a start page. Defaults to index.html.
 
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ app.get('/', function(req, res) {
  
 var server = http.createServer(app)
 
-//reload code here 
+//reload code here
+//optional server delay argument can be given to reload, refer to API below
 reload(server, app)
  
 server.listen(app.get('port'), function(){
@@ -98,6 +99,7 @@ app.get('/', function(req, res) {
 var server = http.createServer(app)
 
 //reload code here
+//optional server delay argument can be given to reload, refer to API below
 reload(server, app)
 
 server.listen(app.get('port'), function(){
@@ -151,7 +153,7 @@ Options:
   -d, --dir [dir]          The directory to serve up. Defaults to current dir.
   -e, --exts [extensions]  Extensions separated by commas or pipes. Defaults to html,js,css.
   -p, --port [port]        The port to bind to. Can be set with PORT env variable as well. Defaults to 8080
-  -t, --time [delay]       How long (ms) should the browser wait before reconnecting? Defaults to 300 ms.
+  -d, --delay [delay]      How long (ms) should the browser wait before reconnecting? Defaults to 300 ms. You can also specify true, if you would like reload to wait until the server comes back up before reloading the page.
 
 ```
 
@@ -173,11 +175,11 @@ It's actually stupidly simple. We leverage `supervisor` to restart the server if
 API
 ---
 
-### reload(httpServer, expressApp, [timeout_millis])
+### reload(httpServer, expressApp, [delay])
 
 - `httpServer`: The Node.js http server from the module `http`.
 - `expressApp`: The express app. It may work with other frameworks, or even with Connect. At this time, it's only been tested with Express.
-- `timeout_millis`: The client side refresh time in milliseconds. Default is `300`.
+- `delay`: The client side refresh time in milliseconds. Default is `300`. You can also specify true, if you would like reload to wait until the server comes back up before reloading the page.
 
 
 

--- a/bin/reload
+++ b/bin/reload
@@ -13,7 +13,7 @@ program.version(require('../package.json').version)
   .option('-d, --dir [dir]', 'The directory to serve up. Defaults to current dir.', process.cwd())
   .option('-e, --exts [extensions]', 'Extensions separated by commas or pipes. Defaults to html,js,css.', 'html|js|css')
   .option('-p, --port [port]', 'The port to bind to. Can be set with PORT env variable as well. Defaults to 8080', '8080')
-  .option('-t, --time [delay]', 'How long (ms) should the browser wait before reconnecting? Defaults to 300 ms.', '300')
+  .option('-d, --delay [delay]', 'How long (ms) should the browser wait before reconnecting? Defaults to 300 ms. You can also specify true, if you would like reload to wait until the server comes back up before reloading the page.', '300')
   .parse(process.argv)
 
 var runFile = path.join(os.tmpdir(), 'reload-' + Math.random().toString().slice(2))

--- a/lib/reload-client.js
+++ b/lib/reload-client.js
@@ -1,10 +1,62 @@
 ;(function refresh () {
   var RLD_TIMEOUT = 300;
   var sock = new SockJS(window.location.origin + '/sockreload');
+  var waitForServer = false;
+  var checkDelay = 1;
+  var checkDelayCounter = 1;
 
   sock.onclose = function() {
-    setTimeout(function() {
-      window.location.reload();
-    },RLD_TIMEOUT);
+    //check for the server only if the user entered in true for a delay
+    if (waitForServer) {
+      checkServerUp(window.location.href, handleResponse)
+    }
+    //else use the default delay or user specified delay
+    else {
+      setTimeout(function() {
+        window.location.reload();
+      },RLD_TIMEOUT);
+    }
+
+    function checkServerUp(url, handleResponse) {
+      var xhr = new XMLHttpRequest();
+      xhr.ontimeout = function () {
+        handleResponse(xhr.status);
+      };
+      xhr.onload = function(e) {
+        if (xhr.readyState === 4) {
+          //server is up, so we send handleResponse xhrstatus, so it can sort out the correct action based on the status
+          handleResponse(xhr.status);
+        }
+        else{
+          handleResponse(xhr.status);
+        }
+      };
+      xhr.onerror = function(e) {
+        //server is up, so we send handleResponse xhrstatus, so it can sort out the correct action based on the status
+        handleResponse(xhr.status);
+      };
+      xhr.open('GET', url, true);
+      xhr.timeout = 100;
+      xhr.send(null);
+    }
+
+    function handleResponse(statusCode) {
+      if (statusCode === 200) {
+        window.location.reload();
+      }
+      else {
+        //this will logarithmically increase the wait time to slow down the calls to checkServerUp to prevent this script from spamming requests if the server doesn’t come back up quickly. 
+        //this is useful in the case when the user brings down the server but forgets to close their dev tab or a server has a long restart time.
+
+        // y = x^6 / 10000000000
+        checkDelay =  (Math.pow(checkDelayCounter,6)) / 10000000000;
+        checkDelayCounter++;
+
+        //if the server is down ask again
+        setTimeout(function () {
+          checkServerUp(window.location.href, handleResponse);
+        }, checkDelay);
+      }
+    }
   };
 })();

--- a/lib/reload-client.js
+++ b/lib/reload-client.js
@@ -2,61 +2,43 @@
   var RLD_TIMEOUT = 300;
   var sock = new SockJS(window.location.origin + '/sockreload');
   var waitForServer = false;
+  var sock;
   var checkDelay = 1;
   var checkDelayCounter = 1;
+
+  var newConn = function() {
+    //try and connect a new socket to the server.
+    sock = new SockJS(window.location.origin + '/sockreload');
+    
+    //if the server is up then, the sockert will reach this event handler and then call refreshPage
+    sock.onopen = function() {
+      window.location.reload();
+    };
+    
+    //else the server is down try and connect again with another call to newConn
+
+    //this will exponentially increase the wait time to slow down the calls to checkServerUp to prevent this script from spamming requests if the server doesn’t come back up quickly. 
+    //this is useful in the case when the user brings down the server but forgets to close their dev tab or a server has a long restart time.
+    checkDelay = (Math.pow(checkDelayCounter,6)) / 10000000000;
+    checkDelayCounter++;
+
+    setTimeout(function () {
+      newConn();
+    }, checkDelay);
+  };
 
   sock.onclose = function() {
     //check for the server only if the user entered in true for a delay
     if (waitForServer) {
-      checkServerUp(window.location.href, handleResponse)
+      sock = null;
+
+      newConn();
     }
     //else use the default delay or user specified delay
     else {
       setTimeout(function() {
         window.location.reload();
       },RLD_TIMEOUT);
-    }
-
-    function checkServerUp(url, handleResponse) {
-      var xhr = new XMLHttpRequest();
-      xhr.ontimeout = function () {
-        handleResponse(xhr.status);
-      };
-      xhr.onload = function(e) {
-        if (xhr.readyState === 4) {
-          //server is up, so we send handleResponse xhrstatus, so it can sort out the correct action based on the status
-          handleResponse(xhr.status);
-        }
-        else{
-          handleResponse(xhr.status);
-        }
-      };
-      xhr.onerror = function(e) {
-        //server is up, so we send handleResponse xhrstatus, so it can sort out the correct action based on the status
-        handleResponse(xhr.status);
-      };
-      xhr.open('GET', url, true);
-      xhr.timeout = 100;
-      xhr.send(null);
-    }
-
-    function handleResponse(statusCode) {
-      if (statusCode === 200) {
-        window.location.reload();
-      }
-      else {
-        //this will exponentially increase the wait time to slow down the calls to checkServerUp to prevent this script from spamming requests if the server doesn’t come back up quickly. 
-        //this is useful in the case when the user brings down the server but forgets to close their dev tab or a server has a long restart time.
-
-        // y = x^6 / 10000000000
-        checkDelay =  (Math.pow(checkDelayCounter,6)) / 10000000000;
-        checkDelayCounter++;
-
-        //if the server is down ask again
-        setTimeout(function () {
-          checkServerUp(window.location.href, handleResponse);
-        }, checkDelay);
-      }
     }
   };
 })();

--- a/lib/reload-client.js
+++ b/lib/reload-client.js
@@ -45,7 +45,7 @@
         window.location.reload();
       }
       else {
-        //this will logarithmically increase the wait time to slow down the calls to checkServerUp to prevent this script from spamming requests if the server doesn’t come back up quickly. 
+        //this will exponentially increase the wait time to slow down the calls to checkServerUp to prevent this script from spamming requests if the server doesn’t come back up quickly. 
         //this is useful in the case when the user brings down the server but forgets to close their dev tab or a server has a long restart time.
 
         // y = x^6 / 10000000000

--- a/lib/reload.js
+++ b/lib/reload.js
@@ -5,13 +5,17 @@ var sockjs = require('sockjs')
 var SOCKJS_FILE = path.join(__dirname, './sockjs-0.3-min.js')
   , RELOAD_FILE = path.join(__dirname, './reload-client.js')
 
-module.exports = function reload (httpServer, expressApp, time_ms) {
+module.exports = function reload (httpServer, expressApp, delay) {
   //this happens at startup of program, so sync is alright
   var sockjsCode = fs.readFileSync(SOCKJS_FILE, 'utf8')
     , reloadCode = fs.readFileSync(RELOAD_FILE, 'utf8')
 
-  if (time_ms) {
-    reloadCode = reloadCode.replace('RLD_TIMEOUT = 300', 'RLD_TIMEOUT = ' + time_ms)
+  // If delay is specified as true then reload will wait for the server to be up before reloading the page
+  if (delay === true) {
+    reloadCode = reloadCode.replace('waitForServer = false;', 'waitForServer = true;')
+  }
+  else if (delay > 0) {
+    reloadCode = reloadCode.replace('RLD_TIMEOUT = 300', 'RLD_TIMEOUT = ' + delay)
   }
 
   var clientCode = sockjsCode + '\n\n' + reloadCode


### PR DESCRIPTION
This feature changes the timeout_millis to delay. Now you can enter true in for a delay and reload will wait and check for the server to be up before it reloads.