### PR TITLE
Fixed flags, added a new flag, and updated documentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 0.4.0 / 2015-08-17
 ------------------
-- add `true` option to `delay` so that it weights indefinitely until server is up https://github.com/jprichardson/reload/pull/21
+- add `true` option to `delay` so that it waits indefinitely until server is up https://github.com/jprichardson/reload/pull/21
 - express 4 routes, https://github.com/jprichardson/reload/pull/24
 
 0.3.0 / 2015-07-17

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ app.get('/', function(req, res) {
 var server = http.createServer(app)
 
 //reload code here
-//optional reload delay argument can be given to reload, refer to [API](https://github.com/jprichardson/reload#api) below
-reload(server, app)
+//optional reload delay and wait argument can be given to reload, refer to [API](https://github.com/jprichardson/reload#api) below
+reload(server, app, [reloadDelay], [wait])
  
 server.listen(app.get('port'), function(){
   console.log("Web server listening on port " + app.get('port'));
@@ -99,8 +99,8 @@ app.get('/', function(req, res) {
 var server = http.createServer(app)
 
 //reload code here
-//optional reload delay argument can be given to reload, refer to [API](https://github.com/jprichardson/reload#api) below
-reload(server, app)
+//optional reload delay and wait argument can be given to reload, refer to [API](https://github.com/jprichardson/reload#api) below
+reload(server, app, [reloadDelay], [wait])
 
 server.listen(app.get('port'), function(){
   console.log("Web server listening on port " + app.get('port'));

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ app.get('/', function(req, res) {
 var server = http.createServer(app)
 
 //reload code here
-//optional server delay argument can be given to reload, refer to API below
+//optional reload delay argument can be given to reload, refer to [API](https://github.com/jprichardson/reload#api) below
 reload(server, app)
  
 server.listen(app.get('port'), function(){
@@ -99,7 +99,7 @@ app.get('/', function(req, res) {
 var server = http.createServer(app)
 
 //reload code here
-//optional server delay argument can be given to reload, refer to API below
+//optional reload delay argument can be given to reload, refer to [API](https://github.com/jprichardson/reload#api) below
 reload(server, app)
 
 server.listen(app.get('port'), function(){
@@ -148,14 +148,14 @@ Usage: reload [options]
 Options:
 
 
-  -h, --help                    Output usage information
-  -V, --version                 Output the version number
-  -b, --browser                 Open in the browser automatically.
-  -d, --dir [dir]               The directory to serve up. Defaults to current dir.
-  -e, --exts [extensions]       Extensions separated by commas or pipes. Defaults to html,js,css.
-  -p, --port [port]             The port to bind to. Can be set with PORT env variable as well. Defaults to 8080
-  -d, --delay [delay]           How long (ms) should the browser wait before reconnecting? You can also specify true, if you would like reload to wait until the server comes back up before reloading the page. Defaults to 300 ms.
-  -s, --start-page [start-page] Specify a start page. Defaults to index.html.
+  -h, --help                         Output usage information
+  -V, --version                      Output the version number
+  -b, --browser                      Open in the browser automatically.
+  -d, --dir [dir]                    The directory to serve up. Defaults to current dir.
+  -e, --exts [extensions]            Extensions separated by commas or pipes. Defaults to html,js,css.
+  -p, --port [port]                  The port to bind to. Can be set with PORT env variable as well. Defaults to 8080
+  -r, --reload-delay [reload-delay] How long (ms) should the browser wait before reconnecting? You can also specify true, if you would like reload to wait until the server comes back up before reloading the page. Defaults to 300 ms.
+  -s, --start-page [start-page]      Specify a start page. Defaults to index.html.
 
 
 ```
@@ -171,18 +171,18 @@ this will open your `index.html` file in the browser. Any changes that you make 
 How does it work?
 -----------------
 
-It's actually stupidly simple. We leverage `supervisor` to restart the server if any file changes. The client side keeps a websocket open, once the websocket closes, the client sets a timeout to reload in approximately 300 ms. Simple huh?
+It's actually stupidly simple. We leverage `supervisor` to restart the server if any file changes. The client side keeps a websocket open, once the websocket closes, the client sets a timeout to reload in approximately 300 ms (or any other time you'd like, refer to [API](https://github.com/jprichardson/reload#api) below. Simple huh?
 
 
 
 API
 ---
 
-### reload(httpServer, expressApp, [delay])
+### reload(httpServer, expressApp, [reloadDelay])
 
 - `httpServer`: The Node.js http server from the module `http`.
 - `expressApp`: The express app. It may work with other frameworks, or even with Connect. At this time, it's only been tested with Express.
-- `delay`: The client side refresh time in milliseconds. Default is `300`. You can also specify true, if you would like reload to wait until the server comes back up before reloading the page.
+- `reloadDelay`: The client side refresh time in milliseconds. Default is `300`. You can also specify true, if you would like reload to wait until the server comes back up before reloading the page.
 
 
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,8 @@ Options:
   -d, --dir [dir]                    The directory to serve up. Defaults to current dir.
   -e, --exts [extensions]            Extensions separated by commas or pipes. Defaults to html,js,css.
   -p, --port [port]                  The port to bind to. Can be set with PORT env variable as well. Defaults to 8080
-  -r, --reload-delay [reload-delay] How long (ms) should the browser wait before reconnecting? You can also specify true, if you would like reload to wait until the server comes back up before reloading the page. Defaults to 300 ms.
+  -r, --reload-delay [reload-delay]  The client side refresh time in milliseconds. Default is `300`. If wait is specified as true this delay becomes the delay of how long the pages waits to reload after the socket is reopened.
+  -w, --wait [wait]                  Specify true, if you would like reload to wait until the server comes back up before reloading the page.
   -s, --start-page [start-page]      Specify a start page. Defaults to index.html.
 
 
@@ -178,11 +179,12 @@ It's actually stupidly simple. We leverage `supervisor` to restart the server if
 API
 ---
 
-### reload(httpServer, expressApp, [reloadDelay])
+### reload(httpServer, expressApp, [reloadDelay], [wait])
 
 - `httpServer`: The Node.js http server from the module `http`.
 - `expressApp`: The express app. It may work with other frameworks, or even with Connect. At this time, it's only been tested with Express.
-- `reloadDelay`: The client side refresh time in milliseconds. Default is `300`. You can also specify true, if you would like reload to wait until the server comes back up before reloading the page.
+- `reloadDelay`: The client side refresh time in milliseconds. Default is `300`. If --wait is true, then this delay is used to determine how long to wait before attempting to reopen after web socket opens.
+- `wait`: If wait is specified as true reload will wait until the server comes back up before reloading the page.
 
 
 
@@ -192,5 +194,4 @@ License
 (MIT License)
 
 Copyright 2013, JP Richardson  <jprichardson@gmail.com>
-
 

--- a/bin/reload
+++ b/bin/reload
@@ -13,7 +13,7 @@ program.version(require('../package.json').version)
   .option('-d, --dir [dir]', 'The directory to serve up. Defaults to current dir.', process.cwd())
   .option('-e, --exts [extensions]', 'Extensions separated by commas or pipes. Defaults to html,js,css.', 'html|js|css')
   .option('-p, --port [port]', 'The port to bind to. Can be set with PORT env variable as well. Defaults to 8080', '8080')
-  .option('-d, --delay [delay]', 'How long (ms) should the browser wait before reconnecting? Defaults to 300 ms. You can also specify true, if you would like reload to wait until the server comes back up before reloading the page.', '300')
+  .option('-r, --reload-delay [reload-delay]', 'How long (ms) should the server wait before refreshing the page? Defaults to 300 ms. You can also specify true, if you would like reload to wait until the server comes back up before reloading the page.', '300')
   .option('-s, --start-page [start-page]', 'Specify a start page. Defaults to index.html', 'index.html')
   .parse(process.argv)
 
@@ -23,7 +23,7 @@ var serverFile = path.join(__dirname, '../lib/reload-server.js')
 if (program.exts.indexOf(','))
   program.exts = program.exts.replace(/\,/g,'|') //replace comma for pipe, that's what supervisor likes
 
-var args = ['-e', 'html|js|css', '-q', '--', serverFile, program.port, program.dir, !!program.browser, runFile, program.time, program.startPage]
+var args = ['-e', 'html|js|css', '-q', '--', serverFile, program.port, program.dir, !!program.browser, runFile, program.reloadDelay, program.startPage]
 supervisor.run(args)
 
 console.log("\n  Reload web server:")

--- a/bin/reload
+++ b/bin/reload
@@ -13,7 +13,8 @@ program.version(require('../package.json').version)
   .option('-d, --dir [dir]', 'The directory to serve up. Defaults to current dir.', process.cwd())
   .option('-e, --exts [extensions]', 'Extensions separated by commas or pipes. Defaults to html,js,css.', 'html|js|css')
   .option('-p, --port [port]', 'The port to bind to. Can be set with PORT env variable as well. Defaults to 8080', '8080')
-  .option('-r, --reload-delay [reload-delay]', 'How long (ms) should the server wait before refreshing the page? Defaults to 300 ms. You can also specify true, if you would like reload to wait until the server comes back up before reloading the page.', '300')
+  .option('-r, --reload-delay [reload-delay]', 'How long (ms) should the server wait before refreshing the page? Defaults to 300 ms. If -w is set to true, this delay becomes how long the page should wait to reload after the socket open.', '300')
+  .option('-w, --wait [wait]', 'Specify whether or not reload should wait until the server comes back up before reloading the page. Defaults to true', 'true') 
   .option('-s, --start-page [start-page]', 'Specify a start page. Defaults to index.html', 'index.html')
   .parse(process.argv)
 
@@ -23,7 +24,7 @@ var serverFile = path.join(__dirname, '../lib/reload-server.js')
 if (program.exts.indexOf(','))
   program.exts = program.exts.replace(/\,/g,'|') //replace comma for pipe, that's what supervisor likes
 
-var args = ['-e', 'html|js|css', '-q', '--', serverFile, program.port, program.dir, !!program.browser, runFile, program.reloadDelay, program.startPage]
+var args = ['-e', 'html|js|css', '-q', '--', serverFile, program.port, program.dir, !!program.browser, runFile, program.reloadDelay, program.wait, program.startPage]
 supervisor.run(args)
 
 console.log("\n  Reload web server:")

--- a/lib/reload-client.js
+++ b/lib/reload-client.js
@@ -31,7 +31,7 @@
     //check for the server only if the user entered in true for a delay
     if (waitForServer) {
       sock = null;
-
+      
       newConn();
     }
     //else use the default delay or user specified delay

--- a/lib/reload-client.js
+++ b/lib/reload-client.js
@@ -1,7 +1,9 @@
 ;(function refresh () {
   var RLD_TIMEOUT = 300;
   var sock = new SockJS(window.location.origin + '/sockreload');
-  var waitForServer = false;
+  var reloadDelay = 300;
+  var socketDelay = 0;
+  var wait = false;
   var sock;
   var checkDelay = 1;
   var checkDelayCounter = 1;
@@ -12,7 +14,9 @@
     
     //if the server is up then, the sockert will reach this event handler and then call refreshPage
     sock.onopen = function() {
-      window.location.reload();
+      setTimeout(function() {
+        window.location.reload()
+      }, socketDelay);
     };
     
     //else the server is down try and connect again with another call to newConn
@@ -29,16 +33,16 @@
 
   sock.onclose = function() {
     //check for the server only if the user entered in true for a delay
-    if (waitForServer) {
+    if (wait) {
       sock = null;
-      
+
       newConn();
     }
     //else use the default delay or user specified delay
     else {
       setTimeout(function() {
         window.location.reload();
-      },RLD_TIMEOUT);
+      },reloadDelay);
     }
   };
 })();

--- a/lib/reload-server.js
+++ b/lib/reload-server.js
@@ -11,7 +11,7 @@ var port = process.argv[2]
   , dir = process.argv[3]
   , openBrowser = (process.argv[4] === 'true')
   , runFile = process.argv[5]
-  , delay = process.argv[6]
+  , reloadDelay = process.argv[6]
   , startPage = process.argv[7]
 
 var router = express.Router();
@@ -24,7 +24,7 @@ router.get('/', function(req, res, next) {
     if (itDoes)
       sendhtml(startFile, res)
     else
-      res.send(404, "Can't find " + startPage)
+	  res.status(404).send("Can't fine " + startPage);
   })
 })
 
@@ -40,7 +40,7 @@ app.use('*html', router);
 app.use(express.static(dir)) //should cache static assets
 
 var server = http.createServer(app)
-reload(server, app, delay)
+reload(server, app, reloadDelay)
 
 server.listen(app.get('port'), function(){
   if (!fs.existsSync(runFile)) {

--- a/lib/reload-server.js
+++ b/lib/reload-server.js
@@ -12,7 +12,8 @@ var port = process.argv[2]
   , openBrowser = (process.argv[4] === 'true')
   , runFile = process.argv[5]
   , reloadDelay = process.argv[6]
-  , startPage = process.argv[7]
+  , wait = process.argv[7]
+  , startPage = process.argv[8]
 
 var router = express.Router();
 
@@ -24,7 +25,7 @@ router.get('/', function(req, res, next) {
     if (itDoes)
       sendhtml(startFile, res)
     else
-	  res.status(404).send("Can't fine " + startPage);
+      res.status(404).send("Can't fine " + startPage);
   })
 })
 
@@ -40,7 +41,7 @@ app.use('*html', router);
 app.use(express.static(dir)) //should cache static assets
 
 var server = http.createServer(app)
-reload(server, app, reloadDelay)
+reload(server, app, reloadDelay, wait)
 
 server.listen(app.get('port'), function(){
   if (!fs.existsSync(runFile)) {

--- a/lib/reload.js
+++ b/lib/reload.js
@@ -5,17 +5,17 @@ var sockjs = require('sockjs')
 var SOCKJS_FILE = path.join(__dirname, './sockjs-0.3-min.js')
   , RELOAD_FILE = path.join(__dirname, './reload-client.js')
 
-module.exports = function reload (httpServer, expressApp, delay) {
+module.exports = function reload (httpServer, expressApp, reloadDelay) {
   //this happens at startup of program, so sync is alright
   var sockjsCode = fs.readFileSync(SOCKJS_FILE, 'utf8')
     , reloadCode = fs.readFileSync(RELOAD_FILE, 'utf8')
 
-  // If delay is specified as true then reload will wait for the server to be up before reloading the page
-  if (delay === true) {
+  //if reloadDelay is specified as true then reload will wait for the server to be up before reloading the page
+  if (reloadDelay === 'true') {
     reloadCode = reloadCode.replace('waitForServer = false;', 'waitForServer = true;')
   }
-  else if (delay > 0) {
-    reloadCode = reloadCode.replace('RLD_TIMEOUT = 300', 'RLD_TIMEOUT = ' + delay)
+  else {
+    reloadCode = reloadCode.replace('RLD_TIMEOUT = 300', 'RLD_TIMEOUT = ' + reloadDelay)
   }
 
   var clientCode = sockjsCode + '\n\n' + reloadCode

--- a/lib/reload.js
+++ b/lib/reload.js
@@ -5,18 +5,18 @@ var sockjs = require('sockjs')
 var SOCKJS_FILE = path.join(__dirname, './sockjs-0.3-min.js')
   , RELOAD_FILE = path.join(__dirname, './reload-client.js')
 
-module.exports = function reload (httpServer, expressApp, reloadDelay) {
+module.exports = function reload (httpServer, expressApp, reloadDelay, wait) {
   //this happens at startup of program, so sync is alright
   var sockjsCode = fs.readFileSync(SOCKJS_FILE, 'utf8')
     , reloadCode = fs.readFileSync(RELOAD_FILE, 'utf8')
 
   //if reloadDelay is specified as true then reload will wait for the server to be up before reloading the page
-  if (reloadDelay === 'true') {
-    reloadCode = reloadCode.replace('waitForServer = false;', 'waitForServer = true;')
+  if (wait === 'true') {
+    reloadCode = reloadCode.replace('wait = false;', 'wait = true;')
+    reloadCode = reloadCode.replace('socketDelay = 0;', 'socketDelay = ' + reloadDelay)
   }
-  else {
-    reloadCode = reloadCode.replace('RLD_TIMEOUT = 300', 'RLD_TIMEOUT = ' + reloadDelay)
-  }
+	
+  reloadCode = reloadCode.replace('reloadDelay = 300;', 'reloadDelay = ' + reloadDelay)
 
   var clientCode = sockjsCode + '\n\n' + reloadCode
 


### PR DESCRIPTION
There were two `-d` flags when using the browser development only ability. I renamed delay to reloadDelay