### PR TITLE
Fixing node.js mode not evaluating wait flag properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ Options:
   -d, --dir [dir]                    The directory to serve up. Defaults to current dir.
   -e, --exts [extensions]            Extensions separated by commas or pipes. Defaults to html,js,css.
   -p, --port [port]                  The port to bind to. Can be set with PORT env variable as well. Defaults to 8080
-  -r, --reload-delay [reload-delay]  The client side refresh time in milliseconds. Default is `300`. If wait is specified as true this delay becomes the delay of how long the pages waits to reload after the socket is reopened.
-  -w, --wait [wait]                  Specify true, if you would like reload to wait until the server comes back up before reloading the page.
+  -r, --reload-delay [reload-delay]  The client side refresh time in milliseconds. Default is `300`. If wait is specified as true (which is by default, see below) this delay becomes the delay of how long the pages waits to reload after the socket is reopened.
+  -w, --wait [wait]                  Specify true, if you would like reload to wait until the server comes back up before reloading the page. Defaults to true
   -s, --start-page [start-page]      Specify a start page. Defaults to index.html.
 
 
@@ -172,7 +172,7 @@ this will open your `index.html` file in the browser. Any changes that you make 
 How does it work?
 -----------------
 
-It's actually stupidly simple. We leverage `supervisor` to restart the server if any file changes. The client side keeps a websocket open, once the websocket closes, the client sets a timeout to reload in approximately 300 ms (or any other time you'd like, refer to [API](https://github.com/jprichardson/reload#api) below. Simple huh?
+It's actually stupidly simple. We leverage `supervisor` to restart the server if any file changes. The client side keeps a websocket open, once the websocket closes, the client sets a timeout to reload in approximately 300 ms (or any other time you'd like, refer to [API](https://github.com/jprichardson/reload#api) below). Simple huh?
 
 
 
@@ -181,10 +181,10 @@ API
 
 ### reload(httpServer, expressApp, [reloadDelay], [wait])
 
-- `httpServer`: The Node.js http server from the module `http`.
-- `expressApp`: The express app. It may work with other frameworks, or even with Connect. At this time, it's only been tested with Express.
-- `reloadDelay`: The client side refresh time in milliseconds. Default is `300`. If --wait is true, then this delay is used to determine how long to wait before attempting to reopen after web socket opens.
-- `wait`: If wait is specified as true reload will wait until the server comes back up before reloading the page.
+- `httpServer`:  The Node.js http server from the module `http`.
+- `expressApp`:  The express app. It may work with other frameworks, or even with Connect. At this time, it's only been tested with Express.
+- `reloadDelay`: The client side refresh time in milliseconds. Default is `300`. If wait is specified as true (which it is be default, see below) this delay becomes the delay of how long the pages waits to reload after the socket is reopened.
+- `wait`:        If wait is specified as true reload will wait until the server comes back up before reloading the page. Defaults to true.
 
 
 

--- a/lib/reload-server.js
+++ b/lib/reload-server.js
@@ -12,7 +12,7 @@ var port = process.argv[2]
   , openBrowser = (process.argv[4] === 'true')
   , runFile = process.argv[5]
   , reloadDelay = process.argv[6]
-  , wait = (string === "process.argv[7]")
+  , wait = (process.argv[7] === 'true' ? true : false)
   , startPage = process.argv[8]
 
 var router = express.Router();

--- a/lib/reload-server.js
+++ b/lib/reload-server.js
@@ -12,7 +12,7 @@ var port = process.argv[2]
   , openBrowser = (process.argv[4] === 'true')
   , runFile = process.argv[5]
   , reloadDelay = process.argv[6]
-  , wait = process.argv[7]
+  , wait = (string === "process.argv[7]")
   , startPage = process.argv[8]
 
 var router = express.Router();
@@ -25,7 +25,7 @@ router.get('/', function(req, res, next) {
     if (itDoes)
       sendhtml(startFile, res)
     else
-      res.status(404).send("Can't fine " + startPage);
+      res.status(404).send("Can't find " + startPage);
   })
 })
 

--- a/lib/reload.js
+++ b/lib/reload.js
@@ -9,9 +9,10 @@ module.exports = function reload (httpServer, expressApp, reloadDelay, wait) {
   //this happens at startup of program, so sync is alright
   var sockjsCode = fs.readFileSync(SOCKJS_FILE, 'utf8')
     , reloadCode = fs.readFileSync(RELOAD_FILE, 'utf8')
-
+    
+    console.log(wait);
   //if reloadDelay is specified as true then reload will wait for the server to be up before reloading the page
-  if (wait === 'true') {
+  if (wait === true) {
     reloadCode = reloadCode.replace('wait = false;', 'wait = true;')
     reloadCode = reloadCode.replace('socketDelay = 0;', 'socketDelay = ' + reloadDelay)
   }

--- a/lib/reload.js
+++ b/lib/reload.js
@@ -9,8 +9,7 @@ module.exports = function reload (httpServer, expressApp, reloadDelay, wait) {
   //this happens at startup of program, so sync is alright
   var sockjsCode = fs.readFileSync(SOCKJS_FILE, 'utf8')
     , reloadCode = fs.readFileSync(RELOAD_FILE, 'utf8')
-    
-    console.log(wait);
+
   //if reloadDelay is specified as true then reload will wait for the server to be up before reloading the page
   if (wait === true) {
     reloadCode = reloadCode.replace('wait = false;', 'wait = true;')


### PR DESCRIPTION
This PR fixes the Node.js option wait flag. Before this PR the wait flag was working properly for the browser development option as it was being checked against a string but not for the Node.js option. I changed the code so that no matter what option you choose to use it checks wait against a bool. I also made some changes to the documentation.