### PR TITLE
Allow reload from node server

### DIFF
--- a/lib/reload-client.js
+++ b/lib/reload-client.js
@@ -1,46 +1,54 @@
 ;(function refresh () {
-  /* global SockJS */
+  var RLD_TIMEOUT = 300;
+  var sock = new SockJS(window.location.origin + '/sockreload');
+  var reloadDelay = 300;
+  var socketDelay = 0;
+  var wait = false;
+  var sock;
+  var checkDelay = 1;
+  var checkDelayCounter = 1;
 
-  var sock = new SockJS(window.location.origin + '/sockreload')
-  var reloadDelay = 300
-  var socketDelay = 0
-  var wait = false
-  var checkDelay = 1
-  var checkDelayCounter = 1
-
-  var newConn = function () {
-    // try and connect a new socket to the server.
-    sock = new SockJS(window.location.origin + '/sockreload')
-
-    // if the server is up then, the sockert will reach this event handler and then call refreshPage
-    sock.onopen = function () {
-      setTimeout(function () {
+  var newConn = function() {
+    //try and connect a new socket to the server.
+    sock = new SockJS(window.location.origin + '/sockreload');
+    
+    //if the server is up then, the sockert will reach this event handler and then call refreshPage
+    sock.onopen = function() {
+      setTimeout(function() {
         window.location.reload()
-      }, socketDelay)
-    }
+      }, socketDelay);
+    };
+    
+    //else the server is down try and connect again with another call to newConn
 
-    // else the server is down try and connect again with another call to newConn
-
-    // this will exponentially increase the wait time to slow down the calls to checkServerUp to prevent this script from spamming requests if the server doesn’t come back up quickly.
-    // this is useful in the case when the user brings down the server but forgets to close their dev tab or a server has a long restart time.
-    checkDelay = (Math.pow(checkDelayCounter, 6)) / 10000000000
-    checkDelayCounter++
+    //this will exponentially increase the wait time to slow down the calls to checkServerUp to prevent this script from spamming requests if the server doesn’t come back up quickly. 
+    //this is useful in the case when the user brings down the server but forgets to close their dev tab or a server has a long restart time.
+    checkDelay = (Math.pow(checkDelayCounter,6)) / 10000000000;
+    checkDelayCounter++;
 
     setTimeout(function () {
-      newConn()
-    }, checkDelay)
-  }
+      newConn();
+    }, checkDelay);
+  };
 
-  sock.onclose = function () {
-    // check for the server only if the user entered in true for a delay
+  sock.onclose = function() {
+    //check for the server only if the user entered in true for a delay
     if (wait) {
-      sock = null
+      sock = null;
 
-      newConn()
-    } else { // else use the default delay or user specified delay
-      setTimeout(function () {
-        window.location.reload()
-      }, reloadDelay)
+      newConn();
     }
-  }
-})()
+    //else use the default delay or user specified delay
+    else {
+      setTimeout(function() {
+        window.location.reload();
+      },reloadDelay);
+    }
+  };
+  
+  sock.onmessage = function(e) {
+    if (e.data === "reload") {
+      sock.onclose();
+    }
+  };
+})();

--- a/lib/reload-client.js
+++ b/lib/reload-client.js
@@ -43,10 +43,10 @@
       }, reloadDelay)
     }
   }
-  
-  sock.onmessage = function(e) {
-    if (e.data === "reload") {
-      sock.onclose();
+
+  sock.onmessage = function (e) {
+    if (e.data === 'reload') {
+      sock.onclose()
     }
-  };
+  }
 })()

--- a/lib/reload-client.js
+++ b/lib/reload-client.js
@@ -1,54 +1,52 @@
 ;(function refresh () {
-  var RLD_TIMEOUT = 300;
-  var sock = new SockJS(window.location.origin + '/sockreload');
-  var reloadDelay = 300;
-  var socketDelay = 0;
-  var wait = false;
-  var sock;
-  var checkDelay = 1;
-  var checkDelayCounter = 1;
+  /* global SockJS */
 
-  var newConn = function() {
-    //try and connect a new socket to the server.
-    sock = new SockJS(window.location.origin + '/sockreload');
-    
-    //if the server is up then, the sockert will reach this event handler and then call refreshPage
-    sock.onopen = function() {
-      setTimeout(function() {
+  var sock = new SockJS(window.location.origin + '/sockreload')
+  var reloadDelay = 300
+  var socketDelay = 0
+  var wait = false
+  var checkDelay = 1
+  var checkDelayCounter = 1
+
+  var newConn = function () {
+    // try and connect a new socket to the server.
+    sock = new SockJS(window.location.origin + '/sockreload')
+
+    // if the server is up then, the sockert will reach this event handler and then call refreshPage
+    sock.onopen = function () {
+      setTimeout(function () {
         window.location.reload()
-      }, socketDelay);
-    };
-    
-    //else the server is down try and connect again with another call to newConn
+      }, socketDelay)
+    }
 
-    //this will exponentially increase the wait time to slow down the calls to checkServerUp to prevent this script from spamming requests if the server doesn’t come back up quickly. 
-    //this is useful in the case when the user brings down the server but forgets to close their dev tab or a server has a long restart time.
-    checkDelay = (Math.pow(checkDelayCounter,6)) / 10000000000;
-    checkDelayCounter++;
+    // else the server is down try and connect again with another call to newConn
+
+    // this will exponentially increase the wait time to slow down the calls to checkServerUp to prevent this script from spamming requests if the server doesn’t come back up quickly.
+    // this is useful in the case when the user brings down the server but forgets to close their dev tab or a server has a long restart time.
+    checkDelay = (Math.pow(checkDelayCounter, 6)) / 10000000000
+    checkDelayCounter++
 
     setTimeout(function () {
-      newConn();
-    }, checkDelay);
-  };
+      newConn()
+    }, checkDelay)
+  }
 
-  sock.onclose = function() {
-    //check for the server only if the user entered in true for a delay
+  sock.onclose = function () {
+    // check for the server only if the user entered in true for a delay
     if (wait) {
-      sock = null;
+      sock = null
 
-      newConn();
+      newConn()
+    } else { // else use the default delay or user specified delay
+      setTimeout(function () {
+        window.location.reload()
+      }, reloadDelay)
     }
-    //else use the default delay or user specified delay
-    else {
-      setTimeout(function() {
-        window.location.reload();
-      },reloadDelay);
-    }
-  };
+  }
   
   sock.onmessage = function(e) {
     if (e.data === "reload") {
       sock.onclose();
     }
   };
-})();
+})()

--- a/lib/reload.js
+++ b/lib/reload.js
@@ -1,30 +1,49 @@
 var sockjs = require('sockjs')
-var path = require('path')
-var fs = require('fs')
+  , path  = require('path')
+  , fs = require('fs')
 
 var SOCKJS_FILE = path.join(__dirname, './sockjs-0.3-min.js')
-var RELOAD_FILE = path.join(__dirname, './reload-client.js')
+  , RELOAD_FILE = path.join(__dirname, './reload-client.js')
 
 module.exports = function reload (httpServer, expressApp, reloadDelay, wait) {
-  // this happens at startup of program, so sync is alright
-  var sockjsCode = fs.readFileSync(SOCKJS_FILE, 'utf8')
-  var reloadCode = fs.readFileSync(RELOAD_FILE, 'utf8')
+  //this happens at startup of program, so sync is alright
+  var conn
+    , sockjsCode = fs.readFileSync(SOCKJS_FILE, 'utf8')
+    , reloadCode = fs.readFileSync(RELOAD_FILE, 'utf8')
 
-  // if reloadDelay is specified as true then reload will wait for the server to be up before reloading the page
+  //if reloadDelay is specified as true then reload will wait for the server to be up before reloading the page
   if (wait === true) {
     reloadCode = reloadCode.replace('wait = false;', 'wait = true;')
     reloadCode = reloadCode.replace('socketDelay = 0;', 'socketDelay = ' + reloadDelay)
   }
-
+	
   reloadCode = reloadCode.replace('reloadDelay = 300;', 'reloadDelay = ' + reloadDelay)
 
   var clientCode = sockjsCode + '\n\n' + reloadCode
 
-  var reload = sockjs.createServer({ log: function () {} })
+  var reload = sockjs.createServer({log: function(){}})
+  reload.on('connection', function (connection) {
+    conn = connection
+  })
   reload.installHandlers(httpServer, {prefix: '/sockreload'})
 
-  expressApp.get('/reload/reload.js', function (req, res) {
+  expressApp.get('/reload/reload.js', function(req, res) {
     res.type('text/javascript')
     res.send(clientCode)
   })
+
+  return {
+    "server": reload,
+    "connection": conn,
+    "reload": function () {
+      this.sendMessage("reload")
+    },
+    "sendMessage": function (command) {
+      if (conn) {
+        conn.write(command)
+      } else {
+        console.log("Cannot send '" + command + "' to client: still not connected")
+      }
+    }
+  }
 }

--- a/lib/reload.js
+++ b/lib/reload.js
@@ -1,33 +1,33 @@
 var sockjs = require('sockjs')
-  , path  = require('path')
-  , fs = require('fs')
+var path = require('path')
+var fs = require('fs')
 
 var SOCKJS_FILE = path.join(__dirname, './sockjs-0.3-min.js')
-  , RELOAD_FILE = path.join(__dirname, './reload-client.js')
+var RELOAD_FILE = path.join(__dirname, './reload-client.js')
 
 module.exports = function reload (httpServer, expressApp, reloadDelay, wait) {
-  //this happens at startup of program, so sync is alright
+  // this happens at startup of program, so sync is alright
+  var sockjsCode = fs.readFileSync(SOCKJS_FILE, 'utf8')
+  var reloadCode = fs.readFileSync(RELOAD_FILE, 'utf8')
   var conn
-    , sockjsCode = fs.readFileSync(SOCKJS_FILE, 'utf8')
-    , reloadCode = fs.readFileSync(RELOAD_FILE, 'utf8')
 
-  //if reloadDelay is specified as true then reload will wait for the server to be up before reloading the page
+  // if reloadDelay is specified as true then reload will wait for the server to be up before reloading the page
   if (wait === true) {
     reloadCode = reloadCode.replace('wait = false;', 'wait = true;')
     reloadCode = reloadCode.replace('socketDelay = 0;', 'socketDelay = ' + reloadDelay)
   }
-	
+
   reloadCode = reloadCode.replace('reloadDelay = 300;', 'reloadDelay = ' + reloadDelay)
 
   var clientCode = sockjsCode + '\n\n' + reloadCode
 
-  var reload = sockjs.createServer({log: function(){}})
+  var reload = sockjs.createServer({ log: function () {} })
   reload.on('connection', function (connection) {
     conn = connection
   })
   reload.installHandlers(httpServer, {prefix: '/sockreload'})
 
-  expressApp.get('/reload/reload.js', function(req, res) {
+  expressApp.get('/reload/reload.js', function (req, res) {
     res.type('text/javascript')
     res.send(clientCode)
   })

--- a/lib/reload.js
+++ b/lib/reload.js
@@ -33,16 +33,16 @@ module.exports = function reload (httpServer, expressApp, reloadDelay, wait) {
   })
 
   return {
-    "server": reload,
-    "connection": conn,
-    "reload": function () {
-      this.sendMessage("reload")
+    'server': reload,
+    'connection': conn,
+    'reload': function () {
+      this.sendMessage('reload')
     },
-    "sendMessage": function (command) {
+    'sendMessage': function (command) {
       if (conn) {
         conn.write(command)
       } else {
-        console.log("Cannot send '" + command + "' to client: still not connected")
+        console.log('Cannot send "' + command + '" to client: still not connected')
       }
     }
   }


### PR DESCRIPTION
In this way, not only nodemon or supervisor can fire a reload event, but you can do:

```javascript
reloadServer = reload(server, app, 1000);
watch.watchTree(__dirname + "/public", function (f, curr, prev) {
    console.log("Trying to reload...");
    reloadServer.reload();
});
```

**Use case:** let's say that you don't want the server to be restarted each time you change client files. In this way one can let nodemon skipping watching public files and let node server watching and reloading browser each time a change is detected in client files.