### PR TITLE
0.8.1 CLI broken on Linux/Mac

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Fix bug on POSIX systems with CRLF line endings (see: https://github.com/npm/npm/issues/2097)
+* text eol=lf


### PR DESCRIPTION
Running `reload` results in: `env: node\r: No such file or directory`

Likely due to publishing from a Windows machine with CRLF line endings. Longstanding NPM bug: npm/npm#2097.

This PR adds a `.gitattributes` file to prevent reversion. But note that a new version will need to be published in order to actually fix.