### PR TITLE
New npm start command + docs

### DIFF
--- a/expressSampleApp/README.md
+++ b/expressSampleApp/README.md
@@ -1,5 +1,5 @@
-The sample app to show how reload works
-=======================================
+The sample app to show reload working
+=====================================
 
 To run the reload server on this sample, make sure you have installed all of the dependencies with `npm install`.
 Then just run `npm start` to start the server.

--- a/expressSampleApp/README.md
+++ b/expressSampleApp/README.md
@@ -1,0 +1,5 @@
+The sample app to show how reload works
+=======================================
+
+To run the reload server on this sample, make sure you have installed all of the dependencies with `npm install`.
+Then just run `npm start` to start the server.

--- a/expressSampleApp/package.json
+++ b/expressSampleApp/package.json
@@ -21,6 +21,6 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node ./node_modueles/reload/bin/reload -d ./public"
+    "start": "node ./node_modules/reload/bin/reload -d ./public"
   }
 }

--- a/expressSampleApp/package.json
+++ b/expressSampleApp/package.json
@@ -21,6 +21,6 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node ./node_modules/reload/bin/reload server.js -d ./public"
+    "start": "node ./node_modueles/reload/bin/reload -d ./public"
   }
 }

--- a/expressSampleApp/package.json
+++ b/expressSampleApp/package.json
@@ -21,6 +21,6 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node server.js"
+    "start": "node ./node_modules/reload/bin/reload server.js -d ./public"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "main": "./lib/reload.js",
   "scripts": {
     "standard": "standard",
-    "test": "npm run standard"
+    "test": "npm run standard",
+    "start": "./bin/reload"
   },
   "bin": {
     "reload": "./bin/reload"


### PR DESCRIPTION
Sets `npm start` to the command which runs the reload server. This lets users easily use the sample server. Also includes a small README.md file which explains how to run the sample server.