### PR TITLE
Replace v0.1 and v0.12 with v6 and v7 (stable and dev) (Closes #73)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: node_js
 node_js:
   - 4
   - 5
-  - 0.12
-  - 0.10
+  - 6
+  - 7
 sudo: false


### PR DESCRIPTION
See #73