### PR TITLE
3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,18 @@
 Next version
 ------------------
 
-3.0.6 / 2020-06-10
+3.1.0 / 2020-06-10
 ------------------
 
 * Changed `passphrase` option from `https.p12.passphrase` to `https.passphrase` so it can be used for certAndKey configurations as well - See: https://github.com/alallier/reload/pull/251
 * Tweaked CI configuration file so GitHub Actions CI will also run on pull requests - See: https://github.com/alallier/reload/pull/250
 * Updated nyc from 15.0.1 to 15.1.0 - See: https://github.com/alallier/reload/pull/249
 * Fix the repository URL in package.json - See: https://github.com/alallier/reload/pull/252
+
+3.0.6 / 2020-06-10
+------------------
+
+* Contains the changes from 3.1.0 but was semantically versioned incorrectly. It is recommended not to use this version and upgrade to 3.1.0
 
 3.0.5 / 2020-05-25
 ------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reload",
-  "version": "3.0.6",
+  "version": "3.1.0",
   "files": [
     "bin",
     "lib",


### PR DESCRIPTION
* Changed `passphrase` option from `https.p12.passphrase` to `https.passphrase` so it can be used for certAndKey configurations as well - See: https://github.com/alallier/reload/pull/251
* Tweaked CI configuration file so GitHub Actions CI will also run on pull requests - See: https://github.com/alallier/reload/pull/250
* Updated nyc from 15.0.1 to 15.1.0 - See: https://github.com/alallier/reload/pull/249
* Fix the repository URL in package.json - See: https://github.com/alallier/reload/pull/252