### PR TITLE
Decode URL pathname.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Next version
 ------------------
 
+3.3.1 / 2025-05-23
+------------------
+
+* Fixed handling of non-ASCII characters in URLs. See: https://github.com/alallier/reload/pull/390
+
 3.3.0 / 2024-08-14
 ------------------
 

--- a/lib/reload-server.js
+++ b/lib/reload-server.js
@@ -39,7 +39,7 @@ const tryFiles = (...files) => {
 const serve = serveStatic(dir, { index: ['index.html', 'index.htm'] })
 
 const server = http.createServer(function (req, res) {
-  const pathname = new URL(req.url, `http://${hostname}`).pathname
+  const pathname = decodeURIComponent(new URL(req.url, `http://${hostname}`).pathname)
 
   const ext = path.extname(pathname)
   const file = path.join(dir, pathname)


### PR DESCRIPTION
Handles non-ASCII characters in URL paths.

Closes: https://github.com/alallier/reload/issues/389